### PR TITLE
1050: RAS Data: Update EQ_L2_FIR[24] to potential checkstop root cause

### DIFF
--- a/analyzer/ras-data/data/ras-data-p10-10.json
+++ b/analyzer/ras-data/data/ras-data-p10-10.json
@@ -18053,7 +18053,8 @@
                 "1c": "core28_M_th_1",
                 "1d": "core29_M_th_1",
                 "1e": "core30_M_th_1",
-                "1f": "core31_M_th_1"
+                "1f": "core31_M_th_1",
+                "flags": ["cs_possible"]
             },
             "19": {
                 "00": "core0_M_level2_L_th_1",

--- a/analyzer/ras-data/data/ras-data-p10-20.json
+++ b/analyzer/ras-data/data/ras-data-p10-20.json
@@ -18053,7 +18053,8 @@
                 "1c": "core28_M_th_1",
                 "1d": "core29_M_th_1",
                 "1e": "core30_M_th_1",
-                "1f": "core31_M_th_1"
+                "1f": "core31_M_th_1",
+                "flags": ["cs_possible"]
             },
             "19": {
                 "00": "core0_M_level2_L_th_1",


### PR DESCRIPTION
#### RAS Data: Update EQ_L2_FIR[24] to potential checkstop root cause
```
Change-Id: I832170dace507ed7c7af8e54b2ebddaf234d549c
Signed-off-by: Caleb Palmer <cnpalmer@us.ibm.com>
```