### PR TITLE
RAS data: add level 2 callout to ME=0 checkstop

### DIFF
--- a/analyzer/ras-data/data/ras-data-p10-10.json
+++ b/analyzer/ras-data/data/ras-data-p10-10.json
@@ -6843,6 +6843,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core0_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core0_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core10_L": [
             {
                 "name": "level2_M",
@@ -6862,6 +6872,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core10_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core10_L_th_1",
                 "type": "action"
             }
         ],
@@ -6887,6 +6907,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core11_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core11_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core12_L": [
             {
                 "name": "level2_M",
@@ -6906,6 +6936,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core12_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core12_L_th_1",
                 "type": "action"
             }
         ],
@@ -6931,6 +6971,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core13_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core13_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core14_L": [
             {
                 "name": "level2_M",
@@ -6950,6 +7000,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core14_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core14_L_th_1",
                 "type": "action"
             }
         ],
@@ -6975,6 +7035,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core15_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core15_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core16_L": [
             {
                 "name": "level2_M",
@@ -6994,6 +7064,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core16_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core16_L_th_1",
                 "type": "action"
             }
         ],
@@ -7019,6 +7099,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core17_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core17_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core18_L": [
             {
                 "name": "level2_M",
@@ -7038,6 +7128,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core18_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core18_L_th_1",
                 "type": "action"
             }
         ],
@@ -7063,6 +7163,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core19_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core19_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core1_L": [
             {
                 "name": "level2_M",
@@ -7082,6 +7192,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core1_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core1_L_th_1",
                 "type": "action"
             }
         ],
@@ -7107,6 +7227,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core20_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core20_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core21_L": [
             {
                 "name": "level2_M",
@@ -7126,6 +7256,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core21_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core21_L_th_1",
                 "type": "action"
             }
         ],
@@ -7151,6 +7291,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core22_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core22_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core23_L": [
             {
                 "name": "level2_M",
@@ -7170,6 +7320,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core23_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core23_L_th_1",
                 "type": "action"
             }
         ],
@@ -7195,6 +7355,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core24_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core24_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core25_L": [
             {
                 "name": "level2_M",
@@ -7214,6 +7384,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core25_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core25_L_th_1",
                 "type": "action"
             }
         ],
@@ -7239,6 +7419,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core26_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core26_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core27_L": [
             {
                 "name": "level2_M",
@@ -7258,6 +7448,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core27_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core27_L_th_1",
                 "type": "action"
             }
         ],
@@ -7283,6 +7483,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core28_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core28_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core29_L": [
             {
                 "name": "level2_M",
@@ -7302,6 +7512,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core29_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core29_L_th_1",
                 "type": "action"
             }
         ],
@@ -7327,6 +7547,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core2_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core2_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core30_L": [
             {
                 "name": "level2_M",
@@ -7346,6 +7576,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core30_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core30_L_th_1",
                 "type": "action"
             }
         ],
@@ -7371,6 +7611,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core31_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core31_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core3_L": [
             {
                 "name": "level2_M",
@@ -7390,6 +7640,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core3_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core3_L_th_1",
                 "type": "action"
             }
         ],
@@ -7415,6 +7675,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core4_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core4_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core5_L": [
             {
                 "name": "level2_M",
@@ -7434,6 +7704,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core5_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core5_L_th_1",
                 "type": "action"
             }
         ],
@@ -7459,6 +7739,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core6_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core6_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core7_L": [
             {
                 "name": "level2_M",
@@ -7478,6 +7768,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core7_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core7_L_th_1",
                 "type": "action"
             }
         ],
@@ -7503,6 +7803,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core8_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core8_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core9_L": [
             {
                 "name": "level2_M",
@@ -7522,6 +7832,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core9_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core9_L_th_1",
                 "type": "action"
             }
         ],
@@ -22247,38 +22567,38 @@
                 "flags": ["cs_possible"]
             },
             "0e": {
-                "00": "core0_M_th_1_sue",
-                "01": "core1_M_th_1_sue",
-                "02": "core2_M_th_1_sue",
-                "03": "core3_M_th_1_sue",
-                "04": "core4_M_th_1_sue",
-                "05": "core5_M_th_1_sue",
-                "06": "core6_M_th_1_sue",
-                "07": "core7_M_th_1_sue",
-                "08": "core8_M_th_1_sue",
-                "09": "core9_M_th_1_sue",
-                "0a": "core10_M_th_1_sue",
-                "0b": "core11_M_th_1_sue",
-                "0c": "core12_M_th_1_sue",
-                "0d": "core13_M_th_1_sue",
-                "0e": "core14_M_th_1_sue",
-                "0f": "core15_M_th_1_sue",
-                "10": "core16_M_th_1_sue",
-                "11": "core17_M_th_1_sue",
-                "12": "core18_M_th_1_sue",
-                "13": "core19_M_th_1_sue",
-                "14": "core20_M_th_1_sue",
-                "15": "core21_M_th_1_sue",
-                "16": "core22_M_th_1_sue",
-                "17": "core23_M_th_1_sue",
-                "18": "core24_M_th_1_sue",
-                "19": "core25_M_th_1_sue",
-                "1a": "core26_M_th_1_sue",
-                "1b": "core27_M_th_1_sue",
-                "1c": "core28_M_th_1_sue",
-                "1d": "core29_M_th_1_sue",
-                "1e": "core30_M_th_1_sue",
-                "1f": "core31_M_th_1_sue"
+                "00": "level2_M_core0_L_th_1_sue",
+                "01": "level2_M_core1_L_th_1_sue",
+                "02": "level2_M_core2_L_th_1_sue",
+                "03": "level2_M_core3_L_th_1_sue",
+                "04": "level2_M_core4_L_th_1_sue",
+                "05": "level2_M_core5_L_th_1_sue",
+                "06": "level2_M_core6_L_th_1_sue",
+                "07": "level2_M_core7_L_th_1_sue",
+                "08": "level2_M_core8_L_th_1_sue",
+                "09": "level2_M_core9_L_th_1_sue",
+                "0a": "level2_M_core10_L_th_1_sue",
+                "0b": "level2_M_core11_L_th_1_sue",
+                "0c": "level2_M_core12_L_th_1_sue",
+                "0d": "level2_M_core13_L_th_1_sue",
+                "0e": "level2_M_core14_L_th_1_sue",
+                "0f": "level2_M_core15_L_th_1_sue",
+                "10": "level2_M_core16_L_th_1_sue",
+                "11": "level2_M_core17_L_th_1_sue",
+                "12": "level2_M_core18_L_th_1_sue",
+                "13": "level2_M_core19_L_th_1_sue",
+                "14": "level2_M_core20_L_th_1_sue",
+                "15": "level2_M_core21_L_th_1_sue",
+                "16": "level2_M_core22_L_th_1_sue",
+                "17": "level2_M_core23_L_th_1_sue",
+                "18": "level2_M_core24_L_th_1_sue",
+                "19": "level2_M_core25_L_th_1_sue",
+                "1a": "level2_M_core26_L_th_1_sue",
+                "1b": "level2_M_core27_L_th_1_sue",
+                "1c": "level2_M_core28_L_th_1_sue",
+                "1d": "level2_M_core29_L_th_1_sue",
+                "1e": "level2_M_core30_L_th_1_sue",
+                "1f": "level2_M_core31_L_th_1_sue"
             },
             "0f": {
                 "00": "level2_M_th_1",

--- a/analyzer/ras-data/data/ras-data-p10-20.json
+++ b/analyzer/ras-data/data/ras-data-p10-20.json
@@ -6843,6 +6843,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core0_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core0_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core10_L": [
             {
                 "name": "level2_M",
@@ -6862,6 +6872,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core10_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core10_L_th_1",
                 "type": "action"
             }
         ],
@@ -6887,6 +6907,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core11_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core11_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core12_L": [
             {
                 "name": "level2_M",
@@ -6906,6 +6936,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core12_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core12_L_th_1",
                 "type": "action"
             }
         ],
@@ -6931,6 +6971,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core13_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core13_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core14_L": [
             {
                 "name": "level2_M",
@@ -6950,6 +7000,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core14_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core14_L_th_1",
                 "type": "action"
             }
         ],
@@ -6975,6 +7035,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core15_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core15_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core16_L": [
             {
                 "name": "level2_M",
@@ -6994,6 +7064,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core16_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core16_L_th_1",
                 "type": "action"
             }
         ],
@@ -7019,6 +7099,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core17_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core17_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core18_L": [
             {
                 "name": "level2_M",
@@ -7038,6 +7128,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core18_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core18_L_th_1",
                 "type": "action"
             }
         ],
@@ -7063,6 +7163,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core19_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core19_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core1_L": [
             {
                 "name": "level2_M",
@@ -7082,6 +7192,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core1_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core1_L_th_1",
                 "type": "action"
             }
         ],
@@ -7107,6 +7227,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core20_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core20_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core21_L": [
             {
                 "name": "level2_M",
@@ -7126,6 +7256,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core21_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core21_L_th_1",
                 "type": "action"
             }
         ],
@@ -7151,6 +7291,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core22_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core22_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core23_L": [
             {
                 "name": "level2_M",
@@ -7170,6 +7320,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core23_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core23_L_th_1",
                 "type": "action"
             }
         ],
@@ -7195,6 +7355,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core24_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core24_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core25_L": [
             {
                 "name": "level2_M",
@@ -7214,6 +7384,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core25_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core25_L_th_1",
                 "type": "action"
             }
         ],
@@ -7239,6 +7419,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core26_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core26_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core27_L": [
             {
                 "name": "level2_M",
@@ -7258,6 +7448,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core27_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core27_L_th_1",
                 "type": "action"
             }
         ],
@@ -7283,6 +7483,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core28_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core28_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core29_L": [
             {
                 "name": "level2_M",
@@ -7302,6 +7512,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core29_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core29_L_th_1",
                 "type": "action"
             }
         ],
@@ -7327,6 +7547,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core2_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core2_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core30_L": [
             {
                 "name": "level2_M",
@@ -7346,6 +7576,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core30_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core30_L_th_1",
                 "type": "action"
             }
         ],
@@ -7371,6 +7611,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core31_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core31_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core3_L": [
             {
                 "name": "level2_M",
@@ -7390,6 +7640,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core3_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core3_L_th_1",
                 "type": "action"
             }
         ],
@@ -7415,6 +7675,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core4_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core4_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core5_L": [
             {
                 "name": "level2_M",
@@ -7434,6 +7704,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core5_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core5_L_th_1",
                 "type": "action"
             }
         ],
@@ -7459,6 +7739,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core6_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core6_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core7_L": [
             {
                 "name": "level2_M",
@@ -7478,6 +7768,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core7_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core7_L_th_1",
                 "type": "action"
             }
         ],
@@ -7503,6 +7803,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core8_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core8_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core9_L": [
             {
                 "name": "level2_M",
@@ -7522,6 +7832,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core9_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core9_L_th_1",
                 "type": "action"
             }
         ],
@@ -22246,38 +22566,38 @@
                 "1f": "level2_M_th_1"
             },
             "0e": {
-                "00": "core0_M_th_1_sue",
-                "01": "core1_M_th_1_sue",
-                "02": "core2_M_th_1_sue",
-                "03": "core3_M_th_1_sue",
-                "04": "core4_M_th_1_sue",
-                "05": "core5_M_th_1_sue",
-                "06": "core6_M_th_1_sue",
-                "07": "core7_M_th_1_sue",
-                "08": "core8_M_th_1_sue",
-                "09": "core9_M_th_1_sue",
-                "0a": "core10_M_th_1_sue",
-                "0b": "core11_M_th_1_sue",
-                "0c": "core12_M_th_1_sue",
-                "0d": "core13_M_th_1_sue",
-                "0e": "core14_M_th_1_sue",
-                "0f": "core15_M_th_1_sue",
-                "10": "core16_M_th_1_sue",
-                "11": "core17_M_th_1_sue",
-                "12": "core18_M_th_1_sue",
-                "13": "core19_M_th_1_sue",
-                "14": "core20_M_th_1_sue",
-                "15": "core21_M_th_1_sue",
-                "16": "core22_M_th_1_sue",
-                "17": "core23_M_th_1_sue",
-                "18": "core24_M_th_1_sue",
-                "19": "core25_M_th_1_sue",
-                "1a": "core26_M_th_1_sue",
-                "1b": "core27_M_th_1_sue",
-                "1c": "core28_M_th_1_sue",
-                "1d": "core29_M_th_1_sue",
-                "1e": "core30_M_th_1_sue",
-                "1f": "core31_M_th_1_sue"
+                "00": "level2_M_core0_L_th_1_sue",
+                "01": "level2_M_core1_L_th_1_sue",
+                "02": "level2_M_core2_L_th_1_sue",
+                "03": "level2_M_core3_L_th_1_sue",
+                "04": "level2_M_core4_L_th_1_sue",
+                "05": "level2_M_core5_L_th_1_sue",
+                "06": "level2_M_core6_L_th_1_sue",
+                "07": "level2_M_core7_L_th_1_sue",
+                "08": "level2_M_core8_L_th_1_sue",
+                "09": "level2_M_core9_L_th_1_sue",
+                "0a": "level2_M_core10_L_th_1_sue",
+                "0b": "level2_M_core11_L_th_1_sue",
+                "0c": "level2_M_core12_L_th_1_sue",
+                "0d": "level2_M_core13_L_th_1_sue",
+                "0e": "level2_M_core14_L_th_1_sue",
+                "0f": "level2_M_core15_L_th_1_sue",
+                "10": "level2_M_core16_L_th_1_sue",
+                "11": "level2_M_core17_L_th_1_sue",
+                "12": "level2_M_core18_L_th_1_sue",
+                "13": "level2_M_core19_L_th_1_sue",
+                "14": "level2_M_core20_L_th_1_sue",
+                "15": "level2_M_core21_L_th_1_sue",
+                "16": "level2_M_core22_L_th_1_sue",
+                "17": "level2_M_core23_L_th_1_sue",
+                "18": "level2_M_core24_L_th_1_sue",
+                "19": "level2_M_core25_L_th_1_sue",
+                "1a": "level2_M_core26_L_th_1_sue",
+                "1b": "level2_M_core27_L_th_1_sue",
+                "1c": "level2_M_core28_L_th_1_sue",
+                "1d": "level2_M_core29_L_th_1_sue",
+                "1e": "level2_M_core30_L_th_1_sue",
+                "1f": "level2_M_core31_L_th_1_sue"
             },
             "0f": {
                 "00": "level2_M_th_1",


### PR DESCRIPTION
After discussion of a field failure it was decided to add a level 2 callout at medium priority so that additional investigation is done to determine root cause before replacing a part. The processor FRU callout is still required by manufacturing. However, it has been moved to low priority because it is least likely that the processor reporting this attention actually is at fault.

Change-Id: Ic375ea6fdaae540626c9501fd0c65e21541b49ca