### PR TITLE
RAS data: add level 2 callout to ME=0 checkstop

### DIFF
--- a/analyzer/ras-data/data/ras-data-p10-10.json
+++ b/analyzer/ras-data/data/ras-data-p10-10.json
@@ -6475,6 +6475,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core0_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core0_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core10_L": [
             {
                 "name": "level2_M",
@@ -6494,6 +6504,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core10_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core10_L_th_1",
                 "type": "action"
             }
         ],
@@ -6519,6 +6539,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core11_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core11_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core12_L": [
             {
                 "name": "level2_M",
@@ -6538,6 +6568,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core12_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core12_L_th_1",
                 "type": "action"
             }
         ],
@@ -6563,6 +6603,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core13_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core13_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core14_L": [
             {
                 "name": "level2_M",
@@ -6582,6 +6632,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core14_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core14_L_th_1",
                 "type": "action"
             }
         ],
@@ -6607,6 +6667,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core15_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core15_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core16_L": [
             {
                 "name": "level2_M",
@@ -6626,6 +6696,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core16_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core16_L_th_1",
                 "type": "action"
             }
         ],
@@ -6651,6 +6731,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core17_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core17_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core18_L": [
             {
                 "name": "level2_M",
@@ -6670,6 +6760,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core18_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core18_L_th_1",
                 "type": "action"
             }
         ],
@@ -6695,6 +6795,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core19_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core19_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core1_L": [
             {
                 "name": "level2_M",
@@ -6714,6 +6824,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core1_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core1_L_th_1",
                 "type": "action"
             }
         ],
@@ -6739,6 +6859,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core20_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core20_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core21_L": [
             {
                 "name": "level2_M",
@@ -6758,6 +6888,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core21_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core21_L_th_1",
                 "type": "action"
             }
         ],
@@ -6783,6 +6923,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core22_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core22_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core23_L": [
             {
                 "name": "level2_M",
@@ -6802,6 +6952,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core23_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core23_L_th_1",
                 "type": "action"
             }
         ],
@@ -6827,6 +6987,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core24_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core24_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core25_L": [
             {
                 "name": "level2_M",
@@ -6846,6 +7016,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core25_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core25_L_th_1",
                 "type": "action"
             }
         ],
@@ -6871,6 +7051,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core26_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core26_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core27_L": [
             {
                 "name": "level2_M",
@@ -6890,6 +7080,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core27_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core27_L_th_1",
                 "type": "action"
             }
         ],
@@ -6915,6 +7115,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core28_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core28_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core29_L": [
             {
                 "name": "level2_M",
@@ -6934,6 +7144,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core29_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core29_L_th_1",
                 "type": "action"
             }
         ],
@@ -6959,6 +7179,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core2_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core2_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core30_L": [
             {
                 "name": "level2_M",
@@ -6978,6 +7208,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core30_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core30_L_th_1",
                 "type": "action"
             }
         ],
@@ -7003,6 +7243,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core31_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core31_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core3_L": [
             {
                 "name": "level2_M",
@@ -7022,6 +7272,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core3_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core3_L_th_1",
                 "type": "action"
             }
         ],
@@ -7047,6 +7307,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core4_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core4_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core5_L": [
             {
                 "name": "level2_M",
@@ -7066,6 +7336,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core5_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core5_L_th_1",
                 "type": "action"
             }
         ],
@@ -7091,6 +7371,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core6_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core6_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core7_L": [
             {
                 "name": "level2_M",
@@ -7110,6 +7400,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core7_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core7_L_th_1",
                 "type": "action"
             }
         ],
@@ -7135,6 +7435,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core8_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core8_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core9_L": [
             {
                 "name": "level2_M",
@@ -7154,6 +7464,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core9_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core9_L_th_1",
                 "type": "action"
             }
         ],
@@ -21879,38 +22199,38 @@
                 "flags": ["cs_possible"]
             },
             "0e": {
-                "00": "core0_M_th_1_sue",
-                "01": "core1_M_th_1_sue",
-                "02": "core2_M_th_1_sue",
-                "03": "core3_M_th_1_sue",
-                "04": "core4_M_th_1_sue",
-                "05": "core5_M_th_1_sue",
-                "06": "core6_M_th_1_sue",
-                "07": "core7_M_th_1_sue",
-                "08": "core8_M_th_1_sue",
-                "09": "core9_M_th_1_sue",
-                "0a": "core10_M_th_1_sue",
-                "0b": "core11_M_th_1_sue",
-                "0c": "core12_M_th_1_sue",
-                "0d": "core13_M_th_1_sue",
-                "0e": "core14_M_th_1_sue",
-                "0f": "core15_M_th_1_sue",
-                "10": "core16_M_th_1_sue",
-                "11": "core17_M_th_1_sue",
-                "12": "core18_M_th_1_sue",
-                "13": "core19_M_th_1_sue",
-                "14": "core20_M_th_1_sue",
-                "15": "core21_M_th_1_sue",
-                "16": "core22_M_th_1_sue",
-                "17": "core23_M_th_1_sue",
-                "18": "core24_M_th_1_sue",
-                "19": "core25_M_th_1_sue",
-                "1a": "core26_M_th_1_sue",
-                "1b": "core27_M_th_1_sue",
-                "1c": "core28_M_th_1_sue",
-                "1d": "core29_M_th_1_sue",
-                "1e": "core30_M_th_1_sue",
-                "1f": "core31_M_th_1_sue"
+                "00": "level2_M_core0_L_th_1_sue",
+                "01": "level2_M_core1_L_th_1_sue",
+                "02": "level2_M_core2_L_th_1_sue",
+                "03": "level2_M_core3_L_th_1_sue",
+                "04": "level2_M_core4_L_th_1_sue",
+                "05": "level2_M_core5_L_th_1_sue",
+                "06": "level2_M_core6_L_th_1_sue",
+                "07": "level2_M_core7_L_th_1_sue",
+                "08": "level2_M_core8_L_th_1_sue",
+                "09": "level2_M_core9_L_th_1_sue",
+                "0a": "level2_M_core10_L_th_1_sue",
+                "0b": "level2_M_core11_L_th_1_sue",
+                "0c": "level2_M_core12_L_th_1_sue",
+                "0d": "level2_M_core13_L_th_1_sue",
+                "0e": "level2_M_core14_L_th_1_sue",
+                "0f": "level2_M_core15_L_th_1_sue",
+                "10": "level2_M_core16_L_th_1_sue",
+                "11": "level2_M_core17_L_th_1_sue",
+                "12": "level2_M_core18_L_th_1_sue",
+                "13": "level2_M_core19_L_th_1_sue",
+                "14": "level2_M_core20_L_th_1_sue",
+                "15": "level2_M_core21_L_th_1_sue",
+                "16": "level2_M_core22_L_th_1_sue",
+                "17": "level2_M_core23_L_th_1_sue",
+                "18": "level2_M_core24_L_th_1_sue",
+                "19": "level2_M_core25_L_th_1_sue",
+                "1a": "level2_M_core26_L_th_1_sue",
+                "1b": "level2_M_core27_L_th_1_sue",
+                "1c": "level2_M_core28_L_th_1_sue",
+                "1d": "level2_M_core29_L_th_1_sue",
+                "1e": "level2_M_core30_L_th_1_sue",
+                "1f": "level2_M_core31_L_th_1_sue"
             },
             "0f": {
                 "00": "level2_M_th_1",

--- a/analyzer/ras-data/data/ras-data-p10-20.json
+++ b/analyzer/ras-data/data/ras-data-p10-20.json
@@ -6475,6 +6475,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core0_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core0_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core10_L": [
             {
                 "name": "level2_M",
@@ -6494,6 +6504,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core10_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core10_L_th_1",
                 "type": "action"
             }
         ],
@@ -6519,6 +6539,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core11_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core11_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core12_L": [
             {
                 "name": "level2_M",
@@ -6538,6 +6568,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core12_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core12_L_th_1",
                 "type": "action"
             }
         ],
@@ -6563,6 +6603,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core13_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core13_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core14_L": [
             {
                 "name": "level2_M",
@@ -6582,6 +6632,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core14_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core14_L_th_1",
                 "type": "action"
             }
         ],
@@ -6607,6 +6667,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core15_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core15_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core16_L": [
             {
                 "name": "level2_M",
@@ -6626,6 +6696,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core16_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core16_L_th_1",
                 "type": "action"
             }
         ],
@@ -6651,6 +6731,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core17_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core17_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core18_L": [
             {
                 "name": "level2_M",
@@ -6670,6 +6760,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core18_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core18_L_th_1",
                 "type": "action"
             }
         ],
@@ -6695,6 +6795,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core19_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core19_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core1_L": [
             {
                 "name": "level2_M",
@@ -6714,6 +6824,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core1_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core1_L_th_1",
                 "type": "action"
             }
         ],
@@ -6739,6 +6859,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core20_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core20_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core21_L": [
             {
                 "name": "level2_M",
@@ -6758,6 +6888,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core21_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core21_L_th_1",
                 "type": "action"
             }
         ],
@@ -6783,6 +6923,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core22_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core22_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core23_L": [
             {
                 "name": "level2_M",
@@ -6802,6 +6952,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core23_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core23_L_th_1",
                 "type": "action"
             }
         ],
@@ -6827,6 +6987,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core24_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core24_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core25_L": [
             {
                 "name": "level2_M",
@@ -6846,6 +7016,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core25_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core25_L_th_1",
                 "type": "action"
             }
         ],
@@ -6871,6 +7051,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core26_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core26_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core27_L": [
             {
                 "name": "level2_M",
@@ -6890,6 +7080,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core27_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core27_L_th_1",
                 "type": "action"
             }
         ],
@@ -6915,6 +7115,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core28_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core28_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core29_L": [
             {
                 "name": "level2_M",
@@ -6934,6 +7144,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core29_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core29_L_th_1",
                 "type": "action"
             }
         ],
@@ -6959,6 +7179,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core2_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core2_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core30_L": [
             {
                 "name": "level2_M",
@@ -6978,6 +7208,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core30_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core30_L_th_1",
                 "type": "action"
             }
         ],
@@ -7003,6 +7243,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core31_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core31_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core3_L": [
             {
                 "name": "level2_M",
@@ -7022,6 +7272,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core3_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core3_L_th_1",
                 "type": "action"
             }
         ],
@@ -7047,6 +7307,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core4_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core4_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core5_L": [
             {
                 "name": "level2_M",
@@ -7066,6 +7336,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core5_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core5_L_th_1",
                 "type": "action"
             }
         ],
@@ -7091,6 +7371,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core6_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core6_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core7_L": [
             {
                 "name": "level2_M",
@@ -7110,6 +7400,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core7_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core7_L_th_1",
                 "type": "action"
             }
         ],
@@ -7135,6 +7435,16 @@
                 "type": "action"
             }
         ],
+        "level2_M_core8_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core8_L_th_1",
+                "type": "action"
+            }
+        ],
         "level2_M_core9_L": [
             {
                 "name": "level2_M",
@@ -7154,6 +7464,16 @@
             },
             {
                 "name": "th_1",
+                "type": "action"
+            }
+        ],
+        "level2_M_core9_L_th_1_sue": [
+            {
+                "name": "sue_seen_H",
+                "type": "action"
+            },
+            {
+                "name": "level2_M_core9_L_th_1",
                 "type": "action"
             }
         ],
@@ -21878,38 +22198,38 @@
                 "1f": "level2_M_th_1"
             },
             "0e": {
-                "00": "core0_M_th_1_sue",
-                "01": "core1_M_th_1_sue",
-                "02": "core2_M_th_1_sue",
-                "03": "core3_M_th_1_sue",
-                "04": "core4_M_th_1_sue",
-                "05": "core5_M_th_1_sue",
-                "06": "core6_M_th_1_sue",
-                "07": "core7_M_th_1_sue",
-                "08": "core8_M_th_1_sue",
-                "09": "core9_M_th_1_sue",
-                "0a": "core10_M_th_1_sue",
-                "0b": "core11_M_th_1_sue",
-                "0c": "core12_M_th_1_sue",
-                "0d": "core13_M_th_1_sue",
-                "0e": "core14_M_th_1_sue",
-                "0f": "core15_M_th_1_sue",
-                "10": "core16_M_th_1_sue",
-                "11": "core17_M_th_1_sue",
-                "12": "core18_M_th_1_sue",
-                "13": "core19_M_th_1_sue",
-                "14": "core20_M_th_1_sue",
-                "15": "core21_M_th_1_sue",
-                "16": "core22_M_th_1_sue",
-                "17": "core23_M_th_1_sue",
-                "18": "core24_M_th_1_sue",
-                "19": "core25_M_th_1_sue",
-                "1a": "core26_M_th_1_sue",
-                "1b": "core27_M_th_1_sue",
-                "1c": "core28_M_th_1_sue",
-                "1d": "core29_M_th_1_sue",
-                "1e": "core30_M_th_1_sue",
-                "1f": "core31_M_th_1_sue"
+                "00": "level2_M_core0_L_th_1_sue",
+                "01": "level2_M_core1_L_th_1_sue",
+                "02": "level2_M_core2_L_th_1_sue",
+                "03": "level2_M_core3_L_th_1_sue",
+                "04": "level2_M_core4_L_th_1_sue",
+                "05": "level2_M_core5_L_th_1_sue",
+                "06": "level2_M_core6_L_th_1_sue",
+                "07": "level2_M_core7_L_th_1_sue",
+                "08": "level2_M_core8_L_th_1_sue",
+                "09": "level2_M_core9_L_th_1_sue",
+                "0a": "level2_M_core10_L_th_1_sue",
+                "0b": "level2_M_core11_L_th_1_sue",
+                "0c": "level2_M_core12_L_th_1_sue",
+                "0d": "level2_M_core13_L_th_1_sue",
+                "0e": "level2_M_core14_L_th_1_sue",
+                "0f": "level2_M_core15_L_th_1_sue",
+                "10": "level2_M_core16_L_th_1_sue",
+                "11": "level2_M_core17_L_th_1_sue",
+                "12": "level2_M_core18_L_th_1_sue",
+                "13": "level2_M_core19_L_th_1_sue",
+                "14": "level2_M_core20_L_th_1_sue",
+                "15": "level2_M_core21_L_th_1_sue",
+                "16": "level2_M_core22_L_th_1_sue",
+                "17": "level2_M_core23_L_th_1_sue",
+                "18": "level2_M_core24_L_th_1_sue",
+                "19": "level2_M_core25_L_th_1_sue",
+                "1a": "level2_M_core26_L_th_1_sue",
+                "1b": "level2_M_core27_L_th_1_sue",
+                "1c": "level2_M_core28_L_th_1_sue",
+                "1d": "level2_M_core29_L_th_1_sue",
+                "1e": "level2_M_core30_L_th_1_sue",
+                "1f": "level2_M_core31_L_th_1_sue"
             },
             "0f": {
                 "00": "level2_M_th_1",


### PR DESCRIPTION
After discussion of a field failure it was decided to add a level 2 callout at medium priority so that additional investigation is done to determine root cause before replacing a part. The processor FRU callout is still required by manufacturing. However, it has been moved to low priority because it is least likely that the processor reporting this attention actually is at fault.

Change-Id: Ic375ea6fdaae540626c9501fd0c65e21541b49ca