### PR TITLE
1050: Fix null pointer exception in tracing code

### DIFF
--- a/util/trace.hpp
+++ b/util/trace.hpp
@@ -14,10 +14,6 @@
 namespace trace
 {
 
-#ifndef TEST_TRACE
-constexpr size_t MSG_MAX_LEN = 256;
-#endif
-
 /** @brief Information trace (va_list format). */
 inline void inf(const char* format, va_list args)
 {
@@ -28,9 +24,11 @@ inline void inf(const char* format, va_list args)
 
 #else
 
-    char msg[MSG_MAX_LEN];
-    vsnprintf(msg, MSG_MAX_LEN, format, args);
+    int sz = vsnprintf(nullptr, 0, format, args); // hack to get required size
+    char* msg = new char[sz + 1]();   // allocate room for terminating character
+    vsnprintf(msg, sz, format, args); // print the message
     phosphor::logging::log<phosphor::logging::level::INFO>(msg);
+    delete[] msg;                     // clean up
 
 #endif
 }
@@ -45,9 +43,11 @@ inline void err(const char* format, va_list args)
 
 #else
 
-    char msg[MSG_MAX_LEN];
-    vsnprintf(msg, MSG_MAX_LEN, format, args);
+    int sz = vsnprintf(nullptr, 0, format, args); // hack to get required size
+    char* msg = new char[sz + 1]();   // allocate room for terminating character
+    vsnprintf(msg, sz, format, args); // print the message
     phosphor::logging::log<phosphor::logging::level::ERR>(msg);
+    delete[] msg;                     // clean up
 
 #endif
 }


### PR DESCRIPTION
#### Fix null pointer exception in tracing code
```
Was using snprint() to create a string, but did not leave room for a
null character. This caused a null pointer exception when the string
exceeded the limited string length.

Change-Id: Ia8bb8305549fb4ca1176bdcce5884a230872c0c0
Signed-off-by: Zane Shelley <zshelle@us.ibm.com>
```