### PR TITLE
1060: Fix parameter types in TOD analysis traces

### DIFF
--- a/analyzer/plugins/p10-tod-plugins.cpp
+++ b/analyzer/plugins/p10-tod-plugins.cpp
@@ -138,7 +138,7 @@ bool readRegister(pdbg_target* i_chip, Register i_addr,
     uint64_t scomValue;
     if (util::pdbg::getScom(i_chip, static_cast<uint64_t>(i_addr), scomValue))
     {
-        trace::err("Register read failed: addr=0x%08x chip=%s",
+        trace::err("Register read failed: addr=0x%016" PRIx64 " chip=%s",
                    static_cast<uint64_t>(i_addr), util::pdbg::getPath(i_chip));
         return true; // SCOM failed
     }
@@ -243,7 +243,8 @@ void collectTodFaultData(pdbg_target* i_chip, Data& o_data)
                 trace::inf(
                     "TOD MDMT fault found: top=%u config=%u path=%u chip=%s",
                     static_cast<unsigned int>(top),
-                    static_cast<unsigned int>(topConfig[top]), masterPathSelect,
+                    static_cast<unsigned int>(topConfig[top]),
+                    static_cast<unsigned int>(masterPathSelect),
                     util::pdbg::getPath(i_chip));
 
                 o_data.setMdmtFault(top, i_chip);
@@ -283,8 +284,10 @@ void collectTodFaultData(pdbg_target* i_chip, Data& o_data)
                                "path=%u chip=%s iohs=%u clockSrc=%s",
                                static_cast<unsigned int>(top),
                                static_cast<unsigned int>(topConfig[top]),
-                               slavePathSelect, util::pdbg::getPath(i_chip),
-                               iohsPos, util::pdbg::getPath(chipSourcingClock));
+                               static_cast<unsigned int>(slavePathSelect),
+                               util::pdbg::getPath(i_chip),
+                               static_cast<unsigned int>(iohsPos),
+                               util::pdbg::getPath(chipSourcingClock));
 
                     o_data.setNetworkFault(top, chipSourcingClock, i_chip);
                 }

--- a/util/trace.hpp
+++ b/util/trace.hpp
@@ -26,6 +26,8 @@ inline void inf(const char* format, va_list args1)
     char* msg = new char[sz + 1](); // allocate room for terminating character
     vsnprintf(msg, sz + 1, format, args2); // print the message
 
+    va_end(args2);
+
 #ifdef TEST_TRACE
     fprintf(stdout, "%s\n", msg);
 #else
@@ -46,6 +48,8 @@ inline void err(const char* format, va_list args1)
     int sz = vsnprintf(nullptr, 0, format, args1); // hack to get required size
     char* msg = new char[sz + 1](); // allocate room for terminating character
     vsnprintf(msg, sz + 1, format, args2); // print the message
+
+    va_end(args2);
 
 #ifdef TEST_TRACE
     fprintf(stderr, "%s\n", msg);


### PR DESCRIPTION
#### Fix parameter types in TOD analysis traces
```
Change-Id: Ia289321b4ac447251618fc1becf29e44d9edd4da
Signed-off-by: Zane Shelley <zshelle@us.ibm.com>
```