### PR TITLE
Change PLL callout/guard policy per RAS review

### DIFF
--- a/analyzer/plugins/p10-plugins.cpp
+++ b/analyzer/plugins/p10-plugins.cpp
@@ -39,10 +39,17 @@ void pll_unlock(unsigned int i_instance, const libhei::Chip&,
     // Shrink the size of the PLL list if necessary.
     pllList.resize(std::distance(pllList.begin(), itr));
 
-    // The clock callout priority is dependent on the number of chips with PLL
-    // unlock attentions.
-    auto clockPriority = (1 < pllList.size()) ? callout::Priority::HIGH
-                                              : callout::Priority::MED;
+    // The callout priority is dependent on the number of chips with PLL unlock
+    // attentions.
+    callout::Priority clockPriority = callout::Priority::MED_A;
+    callout::Priority procPriority = callout::Priority::MED_A;
+    bool procGuard = true;
+    if (1 < pllList.size())
+    {
+        clockPriority = callout::Priority::HIGH;
+        procPriority = callout::Priority::MED;
+        procGuard = false;
+    }
 
     // Callout the clock.
     auto clockCallout = (0 == i_instance) ? callout::ClockType::OSC_REF_CLOCK_0
@@ -50,11 +57,11 @@ void pll_unlock(unsigned int i_instance, const libhei::Chip&,
     io_servData.calloutClock(clockCallout, clockPriority, true);
 
     // Callout the processors connected to this clock that are reporting PLL
-    // unlock attentions. Always a medium callout and no guarding.
+    // unlock attentions.
     for (const auto& sig : pllList)
     {
         io_servData.calloutTarget(util::pdbg::getTrgt(sig.getChip()),
-                                  callout::Priority::MED, false);
+                                  procPriority, procGuard);
     }
 }
 

--- a/test/test-pll-unlock.cpp
+++ b/test/test-pll-unlock.cpp
@@ -48,13 +48,15 @@ TEST(PllUnlock, TestSet1)
         "Deconfigured": false,
         "Guarded": false,
         "LocationCode": "P0",
-        "Priority": "M"
+        "Priority": "A"
     },
     {
         "Deconfigured": false,
-        "Guarded": false,
+        "EntityPath": [],
+        "GuardType": "GARD_Unrecoverable",
+        "Guarded": true,
         "LocationCode": "/proc1",
-        "Priority": "M"
+        "Priority": "A"
     }
 ])";
     EXPECT_EQ(s, j.dump(4));
@@ -65,12 +67,12 @@ TEST(PllUnlock, TestSet1)
     {
         "Callout Type": "Clock Callout",
         "Clock Type": "OSC_REF_CLOCK_1",
-        "Priority": "medium"
+        "Priority": "medium_group_A"
     },
     {
         "Callout Type": "Hardware Callout",
-        "Guard": false,
-        "Priority": "medium",
+        "Guard": true,
+        "Priority": "medium_group_A",
         "Target": "/proc1"
     }
 ])";


### PR DESCRIPTION
There is a field issue warranting a policy change on the callout/guard
priorities for the clock and processor callouts on PLL unlock
attentions.

Change-Id: I210518dd811c3114fa75e4f2e68ab285d1f6ad51
Signed-off-by: Zane Shelley <zshelle@us.ibm.com>
